### PR TITLE
18.0 fix violation

### DIFF
--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -215,7 +215,7 @@ class ResCompany(models.Model):
             user_lock_to_date = self.with_context(ignore_exceptions=False)[
                 user_lock_to_date_field
             ]
-            if date < user_lock_to_date
+            if date < user_lock_to_date:
                 violated_date = user_lock_to_date
         return violated_date
 

--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -215,11 +215,8 @@ class ResCompany(models.Model):
             user_lock_to_date = self.with_context(ignore_exceptions=False)[
                 user_lock_to_date_field
             ]
-            violated_date = (
-                None
-                if regular_lock_to_date and date < user_lock_to_date
-                else user_lock_to_date
-            )
+            if date < user_lock_to_date
+                violated_date = user_lock_to_date
         return violated_date
 
     def _get_lock_to_date_violations(

--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -215,7 +215,7 @@ class ResCompany(models.Model):
             user_lock_to_date = self.with_context(ignore_exceptions=False)[
                 user_lock_to_date_field
             ]
-            if date < user_lock_to_date:
+            if regular_lock_to_date and date < user_lock_to_date:
                 violated_date = user_lock_to_date
         return violated_date
 


### PR DESCRIPTION
@thomaspaulb  this solved  our problem . the date should be BEFORE the lock date to return a violation.
It seems that or we misuse lockdates, or the code misinterprets the lockdate, causing a violation to be returned if the "date" of our record is AFTER the lockdate.

tests also consider this logic.  the document date must be less than the lock_date. this causes our unexpected behaviour.